### PR TITLE
export nested messages and enums in built-in json_ts template

### DIFF
--- a/examples/basic/dist/json_ts/skill.ts
+++ b/examples/basic/dist/json_ts/skill.ts
@@ -4,7 +4,7 @@ export interface SkillProto {
   nested?: SkillProtoNestedProto;
 }
 
-interface SkillProtoNestedProto {
+export interface SkillProtoNestedProto {
   a?: string;
   b?: number;
 }

--- a/examples/basic/dist/json_ts/user.ts
+++ b/examples/basic/dist/json_ts/user.ts
@@ -12,7 +12,7 @@ export interface UserProto {
   skills?: SkillProto[];
 }
 
-enum UserProtoGender {
+export enum UserProtoGender {
   male = 0,
   female = 1,
 }

--- a/templates/json_ts/enum.ejs
+++ b/templates/json_ts/enum.ejs
@@ -5,10 +5,9 @@
   } = enumType;
 
   name = prefix + name;
-  var exp = prefix ? '' : 'export ';
 _%>
 <% if (!_.isEmpty(valueList)) { _%>
-<%- exp %>enum <%- name %> {
+export enum <%- name %> {
 <% _.forEach(valueList, (value) => {_%>
   <%-value.name %> = <%-value.number %>,
 <% });_%>

--- a/templates/json_ts/message.ejs
+++ b/templates/json_ts/message.ejs
@@ -12,10 +12,9 @@
   name = prefix + name;
 
   var protoPrefix = '.' + proto.pb_package;
-  var exp = prefix ? '' : 'export ';
 _%>
 <% if (!_.isEmpty(fieldList)) { _%>
-<%- exp %>interface <%- name %> {
+export interface <%- name %> {
 <% _.forEach(fieldList, (field) => {_%>
   <%-include('/field', { field, protoPrefix }) _%>
 <% });_%>


### PR DESCRIPTION
## proto

```proto
message Sample {
  string id = 1;
  Nested nested = 2;
  NestedEnum enum = 3;

  message Nested {
    string id = 1;
  }

  enum NestedEnum {
    a = 0;
    b = 1;
  }
}
```

## before

```ts
export interface Sample {
  id?: string;
  nested?: SampleNested;
  enum?: SampleNestedEnum;
}

// is not exported! it's hard to use.
enum SampleNestedEnum {
  a = 0,
  b = 1,
}

// is not exported! it's hard to use.
interface SampleNested {
  id?: string;
}
```

## after

```ts
export interface Sample {
  id?: string;
  nested?: SampleNested;
  enum?: SampleNestedEnum;
}

// always exported! We can use this directly.
export enum SampleNestedEnum {
  a = 0,
  b = 1,
}

// always exported! We can use this directly.
export interface SampleNested {
  id?: string;
}
```
