### PR TITLE
Fix resolves of dependencies between proto files

### DIFF
--- a/examples/basic/dist/custom/skill.md
+++ b/examples/basic/dist/custom/skill.md
@@ -6,3 +6,9 @@ HELLO
   1. name
   2. power
   3. nested
+- InternalNestedUserProto
+  1. nestedMsg
+  2. nestedEnum
+- RootEnum
+  0. a
+  1. b

--- a/examples/basic/dist/custom/user.md
+++ b/examples/basic/dist/custom/user.md
@@ -10,3 +10,6 @@ HELLO
   5. updatedAt
   6. isDeleted
   7. skills
+- ExternalNestedUserProto
+  1. nestedMsg
+  2. nestedEnum

--- a/examples/basic/dist/json_ts/skill.ts
+++ b/examples/basic/dist/json_ts/skill.ts
@@ -4,8 +4,23 @@ export interface SkillProto {
   nested?: SkillProtoNestedProto;
 }
 
+export enum SkillProtoNestedEnum {
+  a = 0,
+  b = 1,
+}
+
 export interface SkillProtoNestedProto {
   a?: string;
   b?: number;
+}
+
+export interface InternalNestedUserProto {
+  nestedMsg?: SkillProtoNestedProto;
+  nestedEnum?: SkillProtoNestedEnum;
+}
+
+export enum RootEnum {
+  a = 0,
+  b = 1,
 }
 

--- a/examples/basic/dist/json_ts/user.ts
+++ b/examples/basic/dist/json_ts/user.ts
@@ -1,5 +1,7 @@
 import {
   SkillProto,
+  NestedProto,
+  NestedEnum,
 } from './skill';
 
 export interface UserProto {

--- a/examples/basic/dist/json_ts/user.ts
+++ b/examples/basic/dist/json_ts/user.ts
@@ -1,7 +1,7 @@
 import {
   SkillProto,
-  NestedProto,
-  NestedEnum,
+  SkillProtoNestedProto,
+  SkillProtoNestedEnum,
 } from './skill';
 
 export interface UserProto {

--- a/examples/basic/dist/json_ts/user.ts
+++ b/examples/basic/dist/json_ts/user.ts
@@ -17,3 +17,8 @@ export enum UserProtoGender {
   female = 1,
 }
 
+export interface ExternalNestedUserProto {
+  nestedMsg?: SkillProtoNestedProto;
+  nestedEnum?: SkillProtoNestedEnum;
+}
+

--- a/examples/basic/dist/md/skill.md
+++ b/examples/basic/dist/md/skill.md
@@ -11,6 +11,12 @@
 | reserved | bar | | |
 | reserved | | | 4, 8 to 10, 14 |
 
+### NestedEnum
+
+| name | number |
+| ---- | ---- |
+| a | 0 |
+| b | 1 |
 
 ### NestedProto
 
@@ -20,3 +26,17 @@
 | optional | b | int64 | 2 |
 
 
+## InternalNestedUserProto
+
+| label | name | type | number |
+| ----- | ---- | ---- | ------ |
+| optional | nestedMsg | NestedProto | 1 |
+| optional | nestedEnum | NestedEnum | 2 |
+
+
+## RootEnum
+
+| name | number |
+| ---- | ---- |
+| a | 0 |
+| b | 1 |

--- a/examples/basic/dist/md/user.md
+++ b/examples/basic/dist/md/user.md
@@ -19,3 +19,11 @@
 | male | 0 |
 | female | 1 |
 
+## ExternalNestedUserProto
+
+| label | name | type | number |
+| ----- | ---- | ---- | ------ |
+| optional | nestedMsg | NestedProto | 1 |
+| optional | nestedEnum | NestedEnum | 2 |
+
+

--- a/examples/basic/dist/raw/skill.json
+++ b/examples/basic/dist/raw/skill.json
@@ -62,7 +62,23 @@
             "reservedNameList": []
           }
         ],
-        "enumTypeList": [],
+        "enumTypeList": [
+          {
+            "name": "NestedEnum",
+            "valueList": [
+              {
+                "name": "a",
+                "number": 0
+              },
+              {
+                "name": "b",
+                "number": 1
+              }
+            ],
+            "reservedRangeList": [],
+            "reservedNameList": []
+          }
+        ],
         "extensionRangeList": [],
         "oneofDeclList": [],
         "reservedRangeList": [
@@ -83,9 +99,53 @@
           "foo",
           "bar"
         ]
+      },
+      {
+        "name": "InternalNestedUserProto",
+        "fieldList": [
+          {
+            "name": "nestedMsg",
+            "number": 1,
+            "label": 1,
+            "type": 11,
+            "typeName": ".basic.SkillProto.NestedProto",
+            "jsonName": "nestedMsg"
+          },
+          {
+            "name": "nestedEnum",
+            "number": 2,
+            "label": 1,
+            "type": 14,
+            "typeName": ".basic.SkillProto.NestedEnum",
+            "jsonName": "nestedEnum"
+          }
+        ],
+        "extensionList": [],
+        "nestedTypeList": [],
+        "enumTypeList": [],
+        "extensionRangeList": [],
+        "oneofDeclList": [],
+        "reservedRangeList": [],
+        "reservedNameList": []
       }
     ],
-    "enumTypeList": [],
+    "enumTypeList": [
+      {
+        "name": "RootEnum",
+        "valueList": [
+          {
+            "name": "a",
+            "number": 0
+          },
+          {
+            "name": "b",
+            "number": 1
+          }
+        ],
+        "reservedRangeList": [],
+        "reservedNameList": []
+      }
+    ],
     "serviceList": [],
     "extensionList": [],
     "sourceCodeInfo": {
@@ -95,7 +155,7 @@
           "spanList": [
             0,
             0,
-            15,
+            30,
             1
           ],
           "leadingDetachedCommentsList": []
@@ -130,7 +190,7 @@
           "spanList": [
             4,
             0,
-            15,
+            20,
             1
           ],
           "leadingDetachedCommentsList": []
@@ -674,6 +734,394 @@
             15
           ],
           "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            0,
+            4,
+            0
+          ],
+          "spanList": [
+            16,
+            2,
+            19,
+            3
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            0,
+            4,
+            0,
+            1
+          ],
+          "spanList": [
+            16,
+            7,
+            17
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            0,
+            4,
+            0,
+            2,
+            0
+          ],
+          "spanList": [
+            17,
+            4,
+            10
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            0,
+            4,
+            0,
+            2,
+            0,
+            1
+          ],
+          "spanList": [
+            17,
+            4,
+            5
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            0,
+            4,
+            0,
+            2,
+            0,
+            2
+          ],
+          "spanList": [
+            17,
+            8,
+            9
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            0,
+            4,
+            0,
+            2,
+            1
+          ],
+          "spanList": [
+            18,
+            4,
+            10
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            0,
+            4,
+            0,
+            2,
+            1,
+            1
+          ],
+          "spanList": [
+            18,
+            4,
+            5
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            0,
+            4,
+            0,
+            2,
+            1,
+            2
+          ],
+          "spanList": [
+            18,
+            8,
+            9
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            5,
+            0
+          ],
+          "spanList": [
+            22,
+            0,
+            25,
+            1
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            5,
+            0,
+            1
+          ],
+          "spanList": [
+            22,
+            5,
+            13
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            5,
+            0,
+            2,
+            0
+          ],
+          "spanList": [
+            23,
+            2,
+            8
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            5,
+            0,
+            2,
+            0,
+            1
+          ],
+          "spanList": [
+            23,
+            2,
+            3
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            5,
+            0,
+            2,
+            0,
+            2
+          ],
+          "spanList": [
+            23,
+            6,
+            7
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            5,
+            0,
+            2,
+            1
+          ],
+          "spanList": [
+            24,
+            2,
+            8
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            5,
+            0,
+            2,
+            1,
+            1
+          ],
+          "spanList": [
+            24,
+            2,
+            3
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            5,
+            0,
+            2,
+            1,
+            2
+          ],
+          "spanList": [
+            24,
+            6,
+            7
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1
+          ],
+          "spanList": [
+            27,
+            0,
+            30,
+            1
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            1
+          ],
+          "spanList": [
+            27,
+            8,
+            31
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            2,
+            0
+          ],
+          "spanList": [
+            28,
+            2,
+            39
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            2,
+            0,
+            6
+          ],
+          "spanList": [
+            28,
+            2,
+            24
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            2,
+            0,
+            1
+          ],
+          "spanList": [
+            28,
+            25,
+            34
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            2,
+            0,
+            3
+          ],
+          "spanList": [
+            28,
+            37,
+            38
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            2,
+            1
+          ],
+          "spanList": [
+            29,
+            2,
+            39
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            2,
+            1,
+            6
+          ],
+          "spanList": [
+            29,
+            2,
+            23
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            2,
+            1,
+            1
+          ],
+          "spanList": [
+            29,
+            24,
+            34
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            2,
+            1,
+            3
+          ],
+          "spanList": [
+            29,
+            37,
+            38
+          ],
+          "leadingDetachedCommentsList": []
         }
       ]
     },
@@ -742,7 +1190,23 @@
               "reservedNameList": []
             }
           ],
-          "enumTypeList": [],
+          "enumTypeList": [
+            {
+              "name": "NestedEnum",
+              "valueList": [
+                {
+                  "name": "a",
+                  "number": 0
+                },
+                {
+                  "name": "b",
+                  "number": 1
+                }
+              ],
+              "reservedRangeList": [],
+              "reservedNameList": []
+            }
+          ],
           "extensionRangeList": [],
           "oneofDeclList": [],
           "reservedRangeList": [
@@ -763,9 +1227,53 @@
             "foo",
             "bar"
           ]
+        },
+        {
+          "name": "InternalNestedUserProto",
+          "fieldList": [
+            {
+              "name": "nestedMsg",
+              "number": 1,
+              "label": 1,
+              "type": 11,
+              "typeName": ".basic.SkillProto.NestedProto",
+              "jsonName": "nestedMsg"
+            },
+            {
+              "name": "nestedEnum",
+              "number": 2,
+              "label": 1,
+              "type": 14,
+              "typeName": ".basic.SkillProto.NestedEnum",
+              "jsonName": "nestedEnum"
+            }
+          ],
+          "extensionList": [],
+          "nestedTypeList": [],
+          "enumTypeList": [],
+          "extensionRangeList": [],
+          "oneofDeclList": [],
+          "reservedRangeList": [],
+          "reservedNameList": []
         }
       ],
-      "enumTypeList": [],
+      "enumTypeList": [
+        {
+          "name": "RootEnum",
+          "valueList": [
+            {
+              "name": "a",
+              "number": 0
+            },
+            {
+              "name": "b",
+              "number": 1
+            }
+          ],
+          "reservedRangeList": [],
+          "reservedNameList": []
+        }
+      ],
       "serviceList": [],
       "extensionList": [],
       "sourceCodeInfo": {
@@ -775,7 +1283,7 @@
             "spanList": [
               0,
               0,
-              15,
+              30,
               1
             ],
             "leadingDetachedCommentsList": []
@@ -810,7 +1318,7 @@
             "spanList": [
               4,
               0,
-              15,
+              20,
               1
             ],
             "leadingDetachedCommentsList": []
@@ -1354,6 +1862,394 @@
               15
             ],
             "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              0,
+              4,
+              0
+            ],
+            "spanList": [
+              16,
+              2,
+              19,
+              3
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              0,
+              4,
+              0,
+              1
+            ],
+            "spanList": [
+              16,
+              7,
+              17
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              0,
+              4,
+              0,
+              2,
+              0
+            ],
+            "spanList": [
+              17,
+              4,
+              10
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              0,
+              4,
+              0,
+              2,
+              0,
+              1
+            ],
+            "spanList": [
+              17,
+              4,
+              5
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              0,
+              4,
+              0,
+              2,
+              0,
+              2
+            ],
+            "spanList": [
+              17,
+              8,
+              9
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              0,
+              4,
+              0,
+              2,
+              1
+            ],
+            "spanList": [
+              18,
+              4,
+              10
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              0,
+              4,
+              0,
+              2,
+              1,
+              1
+            ],
+            "spanList": [
+              18,
+              4,
+              5
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              0,
+              4,
+              0,
+              2,
+              1,
+              2
+            ],
+            "spanList": [
+              18,
+              8,
+              9
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              5,
+              0
+            ],
+            "spanList": [
+              22,
+              0,
+              25,
+              1
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              5,
+              0,
+              1
+            ],
+            "spanList": [
+              22,
+              5,
+              13
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              5,
+              0,
+              2,
+              0
+            ],
+            "spanList": [
+              23,
+              2,
+              8
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              5,
+              0,
+              2,
+              0,
+              1
+            ],
+            "spanList": [
+              23,
+              2,
+              3
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              5,
+              0,
+              2,
+              0,
+              2
+            ],
+            "spanList": [
+              23,
+              6,
+              7
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              5,
+              0,
+              2,
+              1
+            ],
+            "spanList": [
+              24,
+              2,
+              8
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              5,
+              0,
+              2,
+              1,
+              1
+            ],
+            "spanList": [
+              24,
+              2,
+              3
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              5,
+              0,
+              2,
+              1,
+              2
+            ],
+            "spanList": [
+              24,
+              6,
+              7
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1
+            ],
+            "spanList": [
+              27,
+              0,
+              30,
+              1
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              1
+            ],
+            "spanList": [
+              27,
+              8,
+              31
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              0
+            ],
+            "spanList": [
+              28,
+              2,
+              39
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              0,
+              6
+            ],
+            "spanList": [
+              28,
+              2,
+              24
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              0,
+              1
+            ],
+            "spanList": [
+              28,
+              25,
+              34
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              0,
+              3
+            ],
+            "spanList": [
+              28,
+              37,
+              38
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              1
+            ],
+            "spanList": [
+              29,
+              2,
+              39
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              1,
+              6
+            ],
+            "spanList": [
+              29,
+              2,
+              23
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              1,
+              1
+            ],
+            "spanList": [
+              29,
+              24,
+              34
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              1,
+              3
+            ],
+            "spanList": [
+              29,
+              37,
+              38
+            ],
+            "leadingDetachedCommentsList": []
           }
         ]
       },
@@ -1446,6 +2342,34 @@
           "oneofDeclList": [],
           "reservedRangeList": [],
           "reservedNameList": []
+        },
+        {
+          "name": "ExternalNestedUserProto",
+          "fieldList": [
+            {
+              "name": "nestedMsg",
+              "number": 1,
+              "label": 1,
+              "type": 11,
+              "typeName": ".basic.SkillProto.NestedProto",
+              "jsonName": "nestedMsg"
+            },
+            {
+              "name": "nestedEnum",
+              "number": 2,
+              "label": 1,
+              "type": 14,
+              "typeName": ".basic.SkillProto.NestedEnum",
+              "jsonName": "nestedEnum"
+            }
+          ],
+          "extensionList": [],
+          "nestedTypeList": [],
+          "enumTypeList": [],
+          "extensionRangeList": [],
+          "oneofDeclList": [],
+          "reservedRangeList": [],
+          "reservedNameList": []
         }
       ],
       "enumTypeList": [],
@@ -1458,7 +2382,7 @@
             "spanList": [
               0,
               0,
-              19,
+              24,
               1
             ],
             "leadingDetachedCommentsList": []
@@ -2078,6 +3002,150 @@
               17,
               13,
               14
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1
+            ],
+            "spanList": [
+              21,
+              0,
+              24,
+              1
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              1
+            ],
+            "spanList": [
+              21,
+              8,
+              31
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              0
+            ],
+            "spanList": [
+              22,
+              2,
+              39
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              0,
+              6
+            ],
+            "spanList": [
+              22,
+              2,
+              24
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              0,
+              1
+            ],
+            "spanList": [
+              22,
+              25,
+              34
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              0,
+              3
+            ],
+            "spanList": [
+              22,
+              37,
+              38
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              1
+            ],
+            "spanList": [
+              23,
+              2,
+              39
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              1,
+              6
+            ],
+            "spanList": [
+              23,
+              2,
+              23
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              1,
+              1
+            ],
+            "spanList": [
+              23,
+              24,
+              34
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              1,
+              3
+            ],
+            "spanList": [
+              23,
+              37,
+              38
             ],
             "leadingDetachedCommentsList": []
           }

--- a/examples/basic/dist/raw/user.json
+++ b/examples/basic/dist/raw/user.json
@@ -94,6 +94,34 @@
         "oneofDeclList": [],
         "reservedRangeList": [],
         "reservedNameList": []
+      },
+      {
+        "name": "ExternalNestedUserProto",
+        "fieldList": [
+          {
+            "name": "nestedMsg",
+            "number": 1,
+            "label": 1,
+            "type": 11,
+            "typeName": ".basic.SkillProto.NestedProto",
+            "jsonName": "nestedMsg"
+          },
+          {
+            "name": "nestedEnum",
+            "number": 2,
+            "label": 1,
+            "type": 14,
+            "typeName": ".basic.SkillProto.NestedEnum",
+            "jsonName": "nestedEnum"
+          }
+        ],
+        "extensionList": [],
+        "nestedTypeList": [],
+        "enumTypeList": [],
+        "extensionRangeList": [],
+        "oneofDeclList": [],
+        "reservedRangeList": [],
+        "reservedNameList": []
       }
     ],
     "enumTypeList": [],
@@ -106,7 +134,7 @@
           "spanList": [
             0,
             0,
-            19,
+            24,
             1
           ],
           "leadingDetachedCommentsList": []
@@ -728,6 +756,150 @@
             14
           ],
           "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1
+          ],
+          "spanList": [
+            21,
+            0,
+            24,
+            1
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            1
+          ],
+          "spanList": [
+            21,
+            8,
+            31
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            2,
+            0
+          ],
+          "spanList": [
+            22,
+            2,
+            39
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            2,
+            0,
+            6
+          ],
+          "spanList": [
+            22,
+            2,
+            24
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            2,
+            0,
+            1
+          ],
+          "spanList": [
+            22,
+            25,
+            34
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            2,
+            0,
+            3
+          ],
+          "spanList": [
+            22,
+            37,
+            38
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            2,
+            1
+          ],
+          "spanList": [
+            23,
+            2,
+            39
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            2,
+            1,
+            6
+          ],
+          "spanList": [
+            23,
+            2,
+            23
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            2,
+            1,
+            1
+          ],
+          "spanList": [
+            23,
+            24,
+            34
+          ],
+          "leadingDetachedCommentsList": []
+        },
+        {
+          "pathList": [
+            4,
+            1,
+            2,
+            1,
+            3
+          ],
+          "spanList": [
+            23,
+            37,
+            38
+          ],
+          "leadingDetachedCommentsList": []
         }
       ]
     },
@@ -796,7 +968,23 @@
               "reservedNameList": []
             }
           ],
-          "enumTypeList": [],
+          "enumTypeList": [
+            {
+              "name": "NestedEnum",
+              "valueList": [
+                {
+                  "name": "a",
+                  "number": 0
+                },
+                {
+                  "name": "b",
+                  "number": 1
+                }
+              ],
+              "reservedRangeList": [],
+              "reservedNameList": []
+            }
+          ],
           "extensionRangeList": [],
           "oneofDeclList": [],
           "reservedRangeList": [
@@ -817,9 +1005,53 @@
             "foo",
             "bar"
           ]
+        },
+        {
+          "name": "InternalNestedUserProto",
+          "fieldList": [
+            {
+              "name": "nestedMsg",
+              "number": 1,
+              "label": 1,
+              "type": 11,
+              "typeName": ".basic.SkillProto.NestedProto",
+              "jsonName": "nestedMsg"
+            },
+            {
+              "name": "nestedEnum",
+              "number": 2,
+              "label": 1,
+              "type": 14,
+              "typeName": ".basic.SkillProto.NestedEnum",
+              "jsonName": "nestedEnum"
+            }
+          ],
+          "extensionList": [],
+          "nestedTypeList": [],
+          "enumTypeList": [],
+          "extensionRangeList": [],
+          "oneofDeclList": [],
+          "reservedRangeList": [],
+          "reservedNameList": []
         }
       ],
-      "enumTypeList": [],
+      "enumTypeList": [
+        {
+          "name": "RootEnum",
+          "valueList": [
+            {
+              "name": "a",
+              "number": 0
+            },
+            {
+              "name": "b",
+              "number": 1
+            }
+          ],
+          "reservedRangeList": [],
+          "reservedNameList": []
+        }
+      ],
       "serviceList": [],
       "extensionList": [],
       "sourceCodeInfo": {
@@ -829,7 +1061,7 @@
             "spanList": [
               0,
               0,
-              15,
+              30,
               1
             ],
             "leadingDetachedCommentsList": []
@@ -864,7 +1096,7 @@
             "spanList": [
               4,
               0,
-              15,
+              20,
               1
             ],
             "leadingDetachedCommentsList": []
@@ -1408,6 +1640,394 @@
               15
             ],
             "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              0,
+              4,
+              0
+            ],
+            "spanList": [
+              16,
+              2,
+              19,
+              3
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              0,
+              4,
+              0,
+              1
+            ],
+            "spanList": [
+              16,
+              7,
+              17
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              0,
+              4,
+              0,
+              2,
+              0
+            ],
+            "spanList": [
+              17,
+              4,
+              10
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              0,
+              4,
+              0,
+              2,
+              0,
+              1
+            ],
+            "spanList": [
+              17,
+              4,
+              5
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              0,
+              4,
+              0,
+              2,
+              0,
+              2
+            ],
+            "spanList": [
+              17,
+              8,
+              9
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              0,
+              4,
+              0,
+              2,
+              1
+            ],
+            "spanList": [
+              18,
+              4,
+              10
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              0,
+              4,
+              0,
+              2,
+              1,
+              1
+            ],
+            "spanList": [
+              18,
+              4,
+              5
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              0,
+              4,
+              0,
+              2,
+              1,
+              2
+            ],
+            "spanList": [
+              18,
+              8,
+              9
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              5,
+              0
+            ],
+            "spanList": [
+              22,
+              0,
+              25,
+              1
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              5,
+              0,
+              1
+            ],
+            "spanList": [
+              22,
+              5,
+              13
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              5,
+              0,
+              2,
+              0
+            ],
+            "spanList": [
+              23,
+              2,
+              8
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              5,
+              0,
+              2,
+              0,
+              1
+            ],
+            "spanList": [
+              23,
+              2,
+              3
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              5,
+              0,
+              2,
+              0,
+              2
+            ],
+            "spanList": [
+              23,
+              6,
+              7
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              5,
+              0,
+              2,
+              1
+            ],
+            "spanList": [
+              24,
+              2,
+              8
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              5,
+              0,
+              2,
+              1,
+              1
+            ],
+            "spanList": [
+              24,
+              2,
+              3
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              5,
+              0,
+              2,
+              1,
+              2
+            ],
+            "spanList": [
+              24,
+              6,
+              7
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1
+            ],
+            "spanList": [
+              27,
+              0,
+              30,
+              1
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              1
+            ],
+            "spanList": [
+              27,
+              8,
+              31
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              0
+            ],
+            "spanList": [
+              28,
+              2,
+              39
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              0,
+              6
+            ],
+            "spanList": [
+              28,
+              2,
+              24
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              0,
+              1
+            ],
+            "spanList": [
+              28,
+              25,
+              34
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              0,
+              3
+            ],
+            "spanList": [
+              28,
+              37,
+              38
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              1
+            ],
+            "spanList": [
+              29,
+              2,
+              39
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              1,
+              6
+            ],
+            "spanList": [
+              29,
+              2,
+              23
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              1,
+              1
+            ],
+            "spanList": [
+              29,
+              24,
+              34
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              1,
+              3
+            ],
+            "spanList": [
+              29,
+              37,
+              38
+            ],
+            "leadingDetachedCommentsList": []
           }
         ]
       },
@@ -1500,6 +2120,34 @@
           "oneofDeclList": [],
           "reservedRangeList": [],
           "reservedNameList": []
+        },
+        {
+          "name": "ExternalNestedUserProto",
+          "fieldList": [
+            {
+              "name": "nestedMsg",
+              "number": 1,
+              "label": 1,
+              "type": 11,
+              "typeName": ".basic.SkillProto.NestedProto",
+              "jsonName": "nestedMsg"
+            },
+            {
+              "name": "nestedEnum",
+              "number": 2,
+              "label": 1,
+              "type": 14,
+              "typeName": ".basic.SkillProto.NestedEnum",
+              "jsonName": "nestedEnum"
+            }
+          ],
+          "extensionList": [],
+          "nestedTypeList": [],
+          "enumTypeList": [],
+          "extensionRangeList": [],
+          "oneofDeclList": [],
+          "reservedRangeList": [],
+          "reservedNameList": []
         }
       ],
       "enumTypeList": [],
@@ -1512,7 +2160,7 @@
             "spanList": [
               0,
               0,
-              19,
+              24,
               1
             ],
             "leadingDetachedCommentsList": []
@@ -2132,6 +2780,150 @@
               17,
               13,
               14
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1
+            ],
+            "spanList": [
+              21,
+              0,
+              24,
+              1
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              1
+            ],
+            "spanList": [
+              21,
+              8,
+              31
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              0
+            ],
+            "spanList": [
+              22,
+              2,
+              39
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              0,
+              6
+            ],
+            "spanList": [
+              22,
+              2,
+              24
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              0,
+              1
+            ],
+            "spanList": [
+              22,
+              25,
+              34
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              0,
+              3
+            ],
+            "spanList": [
+              22,
+              37,
+              38
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              1
+            ],
+            "spanList": [
+              23,
+              2,
+              39
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              1,
+              6
+            ],
+            "spanList": [
+              23,
+              2,
+              23
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              1,
+              1
+            ],
+            "spanList": [
+              23,
+              24,
+              34
+            ],
+            "leadingDetachedCommentsList": []
+          },
+          {
+            "pathList": [
+              4,
+              1,
+              2,
+              1,
+              3
+            ],
+            "spanList": [
+              23,
+              37,
+              38
             ],
             "leadingDetachedCommentsList": []
           }

--- a/examples/basic/dist/raw/user.json
+++ b/examples/basic/dist/raw/user.json
@@ -3,7 +3,9 @@
     {
       "fileName": "skill.proto",
       "typeNames": [
-        ".basic.SkillProto"
+        ".basic.SkillProto",
+        ".basic.SkillProto.NestedProto",
+        ".basic.SkillProto.NestedEnum"
       ]
     }
   ],

--- a/examples/basic/proto/skill.proto
+++ b/examples/basic/proto/skill.proto
@@ -13,4 +13,19 @@ message SkillProto {
     string a = 1;
     int64 b = 2;
   }
+
+  enum NestedEnum {
+    a = 0;
+    b = 1;
+  }
+}
+
+enum RootEnum {
+  a = 0;
+  b = 1;
+}
+
+message InternalNestedUserProto {
+  SkillProto.NestedProto nestedMsg = 1;
+  SkillProto.NestedEnum nestedEnum = 2;
 }

--- a/examples/basic/proto/user.proto
+++ b/examples/basic/proto/user.proto
@@ -12,10 +12,14 @@ message UserProto {
   int64 updatedAt = 5;
   bool isDeleted = 6;
   repeated SkillProto skills = 7;
-  
+
   enum Gender {
     male = 0;
     female = 1;
   }
 }
 
+message ExternalNestedUserProto {
+  SkillProto.NestedProto nestedMsg = 1;
+  SkillProto.NestedEnum nestedEnum = 2;
+}

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -25,13 +25,48 @@ function buildFileTypeMap(protos) {
   _.forEach(protos, (proto) => {
     const {name, pb_package: pkg, messageTypeList, enumTypeList} = proto;
     const types = fileTypeMap[name] = [];
-    _.forEach(_.concat(messageTypeList, enumTypeList), (messageOrEnum) => {
-      const {name} = messageOrEnum;
-      types.push(`.${pkg}.${name}`);
-    });
+    const rootPrefix = `.${pkg}`;
+    getTypeNamesInMessage(rootPrefix, messageTypeList)
+      .concat(getTypeNamesInEnum(rootPrefix, enumTypeList))
+      .forEach((name) => types.push(name));
   });
 
   return fileTypeMap;
+}
+
+/**
+ * returns a type names array defined in messageTypeList
+ * @param {String} prefix
+ * @param {Array} messageTypeList
+ * @return {Array}
+ */
+function getTypeNamesInMessage(prefix, messageTypeList) {
+  const types = [];
+
+  _.map(messageTypeList, (messageType) => {
+    const {name, nestedTypeList, enumTypeList} = messageType;
+    const typeName = `${prefix}.${name}`;
+    types.push(typeName);
+
+    getTypeNamesInMessage(typeName, nestedTypeList)
+      .concat(getTypeNamesInEnum(typeName, enumTypeList))
+      .forEach((name) => types.push(name));
+  });
+
+  return types;
+}
+
+/**
+ * returns a type names array defined in enumTypeList
+ * @param {String} prefix
+ * @param {Array} enumTypeList
+ * @return {Array}
+ */
+function getTypeNamesInEnum(prefix, enumTypeList) {
+ return _.map(enumTypeList, (enumType) => {
+    const {name} = enumType;
+    return `${prefix}.${name}`;
+  });
 }
 
 /**

--- a/templates/json_ts/dependency.ejs
+++ b/templates/json_ts/dependency.ejs
@@ -1,7 +1,10 @@
+<%
+  var protoPrefix = '.' + proto.pb_package;
+_%>
 <% if (!_.isEmpty(typeNames)) { _%>
 import {
 <% _.forEach(typeNames, (typeName) => {_%>
-  <%-typeName.split('.').pop() %>,
+  <%-typeName.replace(protoPrefix, '').split('.').join('') %>,
 <% });_%>
 } from './<%-fileName.replace(/\.proto$/, "") %>';
 


### PR DESCRIPTION
I didn't know that we can import nested messages/enums from other proto files like:

```proto
// a.proto
syntax = "proto3";

package sample;

message A {
  NestedProto a = 1;
  NestedEnum b = 2;

  message NestedProto {
    string c = 1;
  }

  enum NestedEnum {
    d = 0;
    e = 1;
  }
}
```

```proto
// b.proto
syntax = "proto3";

package sample;

import "a.proto";

message B {
  A.NestedProto a = 1;
  //^^^^^^^^^^^^^^
  A.NestedEnum b = 2;
  //^^^^^^^^^^^^^^
}
```

this PR fixes process to check dependencies to make use this feature.